### PR TITLE
Update phpstan.rst to warn about baseline not being applied

### DIFF
--- a/doc/integrations/phpstan.rst
+++ b/doc/integrations/phpstan.rst
@@ -13,3 +13,5 @@ To do so you set :ref:`param_language_server_phpstan.enabled`:
 
 - Override the PHPStan level with :ref:`param_language_server_phpstan.level`
 - Specify the path to PHPStan if different to ``/vendor/bin/phpstan`` via. :ref:`param_language_server_phpstan.bin`.
+
+Keep in mind that Phpactor analyzes files with a temporary name, so defining a PHPStan baseline won't work as expected. All detected errors will be reported despite the baseline.


### PR DESCRIPTION
This improvement tries to clarify situations like the one reported in issue #2901